### PR TITLE
Pass approved files through ERB

### DIFF
--- a/lib/approvals/approval.rb
+++ b/lib/approvals/approval.rb
@@ -52,7 +52,7 @@ module Approvals
     end
 
     def received_matches?
-      FileUtils.cmp received_path, approved_path
+      IO.read(received_path) == ERB.new(IO.read(approved_path)).result
     end
 
     def fail_with(message)

--- a/spec/approvals_spec.rb
+++ b/spec/approvals_spec.rb
@@ -74,4 +74,10 @@ describe Approvals do
 
     Approvals.verify executable, :namer => namer
   end
+
+  it "passes approved files through ERB" do
+    $what  = 'greatness'
+    string = "We have, I fear, confused power with greatness."
+    Approvals.verify string, :namer => namer
+  end
 end

--- a/spec/fixtures/approvals/approvals_passes_approved_files_through_erb.approved.txt
+++ b/spec/fixtures/approvals/approvals_passes_approved_files_through_erb.approved.txt
@@ -1,0 +1,1 @@
+We have, I fear, confused power with <%= $what %>.


### PR DESCRIPTION
Hey @kytrinyx, I wanted to get your input on this. 

I keep running into cases where I feel like it might be nice to have certain parts of an approval be dynamic. For instance, when using Rails fixtures with auto-generated `id`s; we care that the `id` is present and correct but we don't care what the actual value is. 

I think an argument could be made that one of the main benefits of approval tests is that they are completely static, but I'm struggling to come up with strong reasons why as long as the approved file is more static than dynamic. Thoughts?
