### PR TITLE
chomp my problems away

### DIFF
--- a/lib/approvals/approval.rb
+++ b/lib/approvals/approval.rb
@@ -52,7 +52,7 @@ module Approvals
     end
 
     def received_matches?
-      IO.read(received_path) == ERB.new(IO.read(approved_path)).result
+      IO.read(received_path).chomp == ERB.new(IO.read(approved_path).chomp).result
     end
 
     def fail_with(message)

--- a/spec/approvals_spec.rb
+++ b/spec/approvals_spec.rb
@@ -67,6 +67,12 @@ describe Approvals do
     Approvals.verify json, :format => :json, :namer => namer
   end
 
+
+  it "verifies json and is newline agnostic" do
+    json = '{"pet":{"species":"turtle","color":"green","name":"Anthony"}}'
+    Approvals.verify json, :format => :json, :namer => namer
+  end
+
   it "verifies an executable" do
     executable = Approvals::Executable.new('SELECT 1') do |command|
       puts "your slip is showing (#{command})"

--- a/spec/fixtures/approvals/approvals_verifies_json_and_is_newline_agnostic.approved.json
+++ b/spec/fixtures/approvals/approvals_verifies_json_and_is_newline_agnostic.approved.json
@@ -1,0 +1,7 @@
+{
+  "pet": {
+    "species": "turtle",
+    "color": "green",
+    "name": "Anthony"
+  }
+}


### PR DESCRIPTION
I was getting some failing tests this morning in exercism.io due to a newline sneaking into one of the fixtures. Assuming that we never care about a newline being at the end, this fixes that. We could also use strip if we never cared about leading or trailing whitespace of any kind.
