### PR TITLE
Update README.md's RSpec section to make the require path more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Since you have not yet approved anything, the `*.approved` file does not exist, 
 
 For the moment the only direct integration is with RSpec.
 
+    require 'approvals/rspec'
+
 The default directory for output files when using RSpec is
 
     spec/fixtures/approvals/


### PR DESCRIPTION
Although it's not too hard to find by looking around in the code, calling this out explicitly is a helpful breadcrumb. I spent a few minutes wondering why I was getting a NoMethodError about :verify from RSpec.
