### PR TITLE
Switch rspec fail_with args so diff is correct

### DIFF
--- a/lib/approvals/extensions/rspec/dsl.rb
+++ b/lib/approvals/extensions/rspec/dsl.rb
@@ -13,7 +13,7 @@ module Approvals
         Approvals.verify(block.call, options.merge(:namer => namer))
       rescue ApprovalError => e
         if diff_on_approval_failure?
-          ::RSpec::Expectations.fail_with(e.message, e.received_text, e.approved_text)
+          ::RSpec::Expectations.fail_with(e.message, e.approved_text, e.received_text)
         else
           raise e
         end


### PR DESCRIPTION
RSpec::Expectations#fail_with message signature is `fail_with(message, expected=nil, actual=nil)` so the approved_text needed to be switched with the received_text for the diff to be the right direction.
