### PR TITLE
Created a first version of a changelog

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## HEAD
+
+* Added configuration option `diff_on_approval_failure`, and functionality to let rspec diff on an approval failure.
+
+
+## Version 0.0.9
+
+Before this version, no changelog was maintained


### PR DESCRIPTION
In my opinion, every serious project should have a changelog. Upgrading large projects with lots of gems can be rather a pain if you have through every diff.

While I'm fully aware this project isn't even 0.1 yet, I think it should be, as it works perfectly fine. Also, as far as I'm aware there is no other mature project which does the same thing either, so this is the best gem to do approvals in ruby, and therefore I think we should work towards making it 'production ready' (even though I think the code already is)
