### PR TITLE
Allow to configure format

### DIFF
--- a/lib/approvals/extensions/rspec.rb
+++ b/lib/approvals/extensions/rspec.rb
@@ -8,5 +8,6 @@ if defined? RSpec
     c.add_setting :approvals_path, :default => 'spec/fixtures/approvals/'
     c.add_setting :approvals_namer_class, :default => Approvals::Namers::DirectoryNamer
     c.add_setting :diff_on_approval_failure, :default => false
+    c.add_setting :approvals_default_format, :default => nil
   end
 end

--- a/lib/approvals/extensions/rspec/dsl.rb
+++ b/lib/approvals/extensions/rspec/dsl.rb
@@ -13,6 +13,8 @@ module Approvals
         defaults = {
           :namer => namer
         }
+        format = ::RSpec.configuration.approvals_default_format
+        defaults[:format] = format if format
         Approvals.verify(block.call, defaults.merge(options))
       rescue ApprovalError => e
         if diff_on_approval_failure?


### PR DESCRIPTION
In our project, all our approvals are json approvals. However, approvals defaults to text. I'd like to be able to state in the spec_helper that they are json, so I can just call `verify {result.body}` instead of `verify(format: :json) { result.body }`
