### PR TITLE
Removed singleton usage

### DIFF
--- a/lib/approvals/writer.rb
+++ b/lib/approvals/writer.rb
@@ -9,22 +9,22 @@ require 'approvals/writers/binary_writer'
 module Approvals
   module Writer
     extend Writers
-    
+
     REGISTRY = {
-      json: Writers::JsonWriter.instance,
-      xml: Writers::XmlWriter.instance,
-      html: Writers::HtmlWriter.instance,
-      hash: Writers::HashWriter.instance,
-      array: Writers::ArrayWriter.instance,
+      json: Writers::JsonWriter.new,
+      xml: Writers::XmlWriter.new,
+      html: Writers::HtmlWriter.new,
+      hash: Writers::HashWriter.new,
+      array: Writers::ArrayWriter.new,
     }
-        
+
 
     class << self
       def for(format)
         if REGISTRY.include?(format)
           REGISTRY[format]
         else
-          TextWriter.instance
+          TextWriter.new
         end
       end
     end

--- a/lib/approvals/writers/binary_writer.rb
+++ b/lib/approvals/writers/binary_writer.rb
@@ -1,10 +1,6 @@
 module Approvals
-
   module Writers
-
     class BinaryWriter
-      include Singleton
-
       EXCEPTION_WRITER = Proc.new do |data, file|
         raise "BinaryWriter#callback missing"
       end
@@ -16,32 +12,32 @@ module Approvals
         self.write = opts[:write] || EXCEPTION_WRITER
         self.format = opts[:format] || :binary
       end
-           
+
       attr_accessor :autoregister
       attr_accessor :extension
       attr_accessor :write
       attr_accessor :detect
-      
-      
+
+
       attr_reader :format
 
       def format=(sym)
         unregister if autoregister
-                
-        @format = sym        
-        
+
+        @format = sym
+
         register if autoregister
-        
+
       end
-      
+
       def register
         if @format
-          Writer::REGISTRY[@format] = self 
+          Writer::REGISTRY[@format] = self
           Approval::BINARY_FORMATS << @format
           Approval::IDENTITIES[@format] = @detect if @detect
         end
       end
-      
+
       def unregister
         if @format
           Writer::REGISTRY.delete!(@format)

--- a/lib/approvals/writers/text_writer.rb
+++ b/lib/approvals/writers/text_writer.rb
@@ -1,8 +1,6 @@
 module Approvals
   module Writers
     class TextWriter
-      include Singleton
-
       def extension
         'txt'
       end


### PR DESCRIPTION
I'm not sure whether there was a specific reason for the singletons, but since they were in the initial extract, they carried no useful commit message. In general, singletons make code hard to debug, and everything seems to work fine without them. The only disadvantage is constructing a few more textwriters, but that doesn't seem to be that heavy, so I don't really see a problem with that.
