### PR TITLE
Updated changelog to incorporate recent changes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,27 @@
 # Changelog
 
-## HEAD
+### HEAD
 
-* Added configuration option `diff_on_approval_failure`, and functionality to let rspec diff on an approval failure.
+- Allow to verify hashes and arrays as json
+
+- Added support for RSpec 3.0
+
+### v0.0.12 (2014/02/16 16:43 +00:00)
+
+- Allow to configure a default format in RSpec
+
+### v0.0.11 (2014/02/16 16:33 +00:00)
+
+- Append a trailing newline to all approval files
 
 
-## Version 0.0.9
+### v0.0.10 (2014/01/30 14:41 +00:00)
+- [#9](https://github.com/kytrinyx/approvals/pull/9) Send rspec approval failures to rspec for diffing (@jeremyruppel)
+
+- [#19](https://github.com/kytrinyx/approvals/pull/19) Switch rspec fail_with args so diff is correct (@bmarini)
+
+- Added configuration option `diff_on_approval_failure`, and functionality to let rspec diff on an approval failure.
+
+### v0.0.9
 
 Before this version, no changelog was maintained


### PR DESCRIPTION
Updated the changelog with recent changes. I used github-changes, which already prefills almost everything, and then summarized. I'm not sure about the format though. We could also do everything in the format they provide, and maybe only tweak the descriptions, but keep links to prs and committers. What do you like best @kytrinyx
