### PR TITLE
Added text to list of export formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,9 @@ Approvals.verify(thing, :name => "the name of your test")
 ### Formatting
 
 You can pass a format for your output before it gets written to the file.
-At the moment, only xml, html, and json are supported.
+At the moment, only text, xml, html, and json are supported.
 
-Simply add a `:format => :xml`, `:format => :html`, or `:format => :json` option to the example:
+Simply add a `:format => :text`, `:format => :xml`, `:format => :html`, or `:format => :json` option to the example:
 
 ```ruby
 page = "<html><head></head><body><h1>ZOMG</h1></body></html>"


### PR DESCRIPTION
This can be confusing when you're working with another default, because it then looks like exports to xml/html/json are the only options.
