### PR TITLE
Switch to Nokogiri::HTML for html writer

### DIFF
--- a/lib/approvals/writers/html_writer.rb
+++ b/lib/approvals/writers/html_writer.rb
@@ -7,7 +7,7 @@ module Approvals
       end
 
       def format(data)
-        Nokogiri::XML(data.to_s.strip,&:noblanks).to_xhtml(:indent => 2, :encoding => 'UTF-8')
+        Nokogiri::HTML(data.to_s.strip,&:noblanks).to_xhtml(:indent => 2, :encoding => 'UTF-8')
       end
 
     end

--- a/spec/approvals_spec.rb
+++ b/spec/approvals_spec.rb
@@ -57,6 +57,17 @@ describe Approvals do
     Approvals.verify html, :format => :html, :namer => namer
   end
 
+  it "verifies a malformed html fragment" do
+    html = <<-HTML
+<!DOCTYPE html>
+<html>
+<title>Hoi</title>
+<script async defer src="http://foo.com/bar.js"></script>
+<h1>yo</h1>
+    HTML
+    Approvals.verify html, :format => :html, :namer => namer
+  end
+
   it "verifies xml" do
     xml = "<xml char=\"kiddo\"><node><content name='beatrice' /></node><node aliases='5'><content /></node></xml>"
     Approvals.verify xml, :format => :xml, :namer => namer

--- a/spec/fixtures/approvals/approvals_verifies_a_malformed_html_fragment.approved.html
+++ b/spec/fixtures/approvals/approvals_verifies_a_malformed_html_fragment.approved.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Hoi</title>
+    <script async="" defer="defer" src="http://foo.com/bar.js"></script>
+  </head>
+  <body>
+    <h1>yo</h1>
+  </body>
+</html>


### PR DESCRIPTION
By switching to the HTML parser from the XML parser, we can better handle malformed html documents and save out something that at least marginally resembles the input HTML.

Resolves kytrinyx/approvals#44
