### PR TITLE
More aggressive filtering of excluded keys

### DIFF
--- a/lib/approvals/filter.rb
+++ b/lib/approvals/filter.rb
@@ -18,7 +18,13 @@ module Approvals
     def censored value, key=nil
       case value
       when Array
-        value.map { |item| censored(item) }
+        if value.empty?
+          value
+        elsif key && placeholder_for(key)
+          "<#{placeholder_for(key)}>"
+        else
+          value.map { |item| censored(item) }
+        end
       when Hash
         Hash[value.map { |key, value| [key, censored(value, key)] }]
       else

--- a/spec/approvals_spec.rb
+++ b/spec/approvals_spec.rb
@@ -108,12 +108,19 @@ describe Approvals do
   end
 
   describe "supports excluded keys option" do
-    let(:hash) { {:object => {:id => rand(100), :created_at => Time.now, :name => 'test', deleted_at: nil}} }
+    let(:hash) { {:object => {
+      :id => rand(100),
+      :other_ids => [1, 2, 3, 4],
+      :created_at => Time.now,
+      :name => 'test',
+      deleted_at: nil
+    }} }
 
     before do
       Approvals.configure do |c|
         c.excluded_json_keys = {
           :id => /(\A|_)id$/,
+          :id_array => /(\A|_)ids$/,
           :date => /_at$/
         }
       end

--- a/spec/fixtures/approvals/approvals_supports_excluded_keys_option_also_supports_an_array_of_hashes.approved.json
+++ b/spec/fixtures/approvals/approvals_supports_excluded_keys_option_also_supports_an_array_of_hashes.approved.json
@@ -2,6 +2,7 @@
   {
     "object": {
       "id": "<id>",
+      "other_ids": "<id_array>",
       "created_at": "<date>",
       "name": "test",
       "deleted_at": null

--- a/spec/fixtures/approvals/approvals_supports_excluded_keys_option_supports_the_array_writer.approved.txt
+++ b/spec/fixtures/approvals/approvals_supports_excluded_keys_option_supports_the_array_writer.approved.txt
@@ -1,1 +1,1 @@
-[0] {:object=>{:id=>"<id>", :created_at=>"<date>", :name=>"test", :deleted_at=>nil}}
+[0] {:object=>{:id=>"<id>", :other_ids=>"<id_array>", :created_at=>"<date>", :name=>"test", :deleted_at=>nil}}

--- a/spec/fixtures/approvals/approvals_supports_excluded_keys_option_supports_the_hash_writer.approved.txt
+++ b/spec/fixtures/approvals/approvals_supports_excluded_keys_option_supports_the_hash_writer.approved.txt
@@ -1,1 +1,1 @@
-[0] [:object, {:id=>"<id>", :created_at=>"<date>", :name=>"test", :deleted_at=>nil}]
+[0] [:object, {:id=>"<id>", :other_ids=>"<id_array>", :created_at=>"<date>", :name=>"test", :deleted_at=>nil}]

--- a/spec/fixtures/approvals/approvals_supports_excluded_keys_option_verifies_json_with_excluded_keys.approved.json
+++ b/spec/fixtures/approvals/approvals_supports_excluded_keys_option_verifies_json_with_excluded_keys.approved.json
@@ -1,6 +1,7 @@
 {
   "object": {
     "id": "<id>",
+    "other_ids": "<id_array>",
     "created_at": "<date>",
     "name": "test",
     "deleted_at": null


### PR DESCRIPTION
Our approvals have a lot of ID arrays, which can't be filtered out using `excluded_json_keys`. This means we end up having to update more approvals files than should be necessary, when we make a simple change to a spec.

This PR tweaks the filtering so we filter out whole arrays (in addition to simple values) if a key matches `excluded_json_keys`.

It may be too aggressive for general use, so not sure if we'll want to push this upstream. But it'll definitely save us time.
