### PR TITLE
Refactor Launcher

### DIFF
--- a/lib/approvals/reporters/diffmerge_reporter.rb
+++ b/lib/approvals/reporters/diffmerge_reporter.rb
@@ -1,6 +1,9 @@
 module Approvals
   module Reporters
     class DiffmergeReporter < NamedReporter
+      def self.command(received, approved)
+        "/Applications/DiffMerge.app/Contents/MacOS/DiffMerge --nosplash \"#{received}\" \"#{approved}\""
+      end
     end
   end
 end

--- a/lib/approvals/reporters/diffmerge_reporter.rb
+++ b/lib/approvals/reporters/diffmerge_reporter.rb
@@ -1,12 +1,6 @@
 module Approvals
   module Reporters
-    class DiffmergeReporter < Reporter
-      include Singleton
-
-      def self.report(received, approved)
-        instance.report(received, approved)
-      end
-
+    class DiffmergeReporter < SingletonReporter
       def default_launcher
         Launcher.diffmerge
       end

--- a/lib/approvals/reporters/diffmerge_reporter.rb
+++ b/lib/approvals/reporters/diffmerge_reporter.rb
@@ -1,6 +1,6 @@
 module Approvals
   module Reporters
-    class DiffmergeReporter < SingletonReporter
+    class DiffmergeReporter < NamedReporter
     end
   end
 end

--- a/lib/approvals/reporters/diffmerge_reporter.rb
+++ b/lib/approvals/reporters/diffmerge_reporter.rb
@@ -1,9 +1,6 @@
 module Approvals
   module Reporters
     class DiffmergeReporter < SingletonReporter
-      def default_launcher
-        Launcher.diffmerge
-      end
     end
   end
 end

--- a/lib/approvals/reporters/filelauncher_reporter.rb
+++ b/lib/approvals/reporters/filelauncher_reporter.rb
@@ -1,6 +1,9 @@
 module Approvals
   module Reporters
     class FilelauncherReporter < NamedReporter
+      def self.command(received, _)
+        "open #{received}"
+      end
     end
   end
 end

--- a/lib/approvals/reporters/filelauncher_reporter.rb
+++ b/lib/approvals/reporters/filelauncher_reporter.rb
@@ -2,7 +2,7 @@ module Approvals
   module Reporters
     class FilelauncherReporter < NamedReporter
       def self.command(received, _)
-        "open #{received}"
+        "open \"#{received}\""
       end
     end
   end

--- a/lib/approvals/reporters/filelauncher_reporter.rb
+++ b/lib/approvals/reporters/filelauncher_reporter.rb
@@ -1,12 +1,6 @@
 module Approvals
   module Reporters
-    class FilelauncherReporter < Reporter
-      include Singleton
-
-      def self.report(received, approved = nil)
-        instance.report(received, approved)
-      end
-
+    class FilelauncherReporter < SingletonReporter
       def default_launcher
         Launcher.filelauncher
       end

--- a/lib/approvals/reporters/filelauncher_reporter.rb
+++ b/lib/approvals/reporters/filelauncher_reporter.rb
@@ -1,9 +1,6 @@
 module Approvals
   module Reporters
     class FilelauncherReporter < SingletonReporter
-      def default_launcher
-        Launcher.filelauncher
-      end
     end
   end
 end

--- a/lib/approvals/reporters/filelauncher_reporter.rb
+++ b/lib/approvals/reporters/filelauncher_reporter.rb
@@ -1,6 +1,6 @@
 module Approvals
   module Reporters
-    class FilelauncherReporter < SingletonReporter
+    class FilelauncherReporter < NamedReporter
     end
   end
 end

--- a/lib/approvals/reporters/launcher.rb
+++ b/lib/approvals/reporters/launcher.rb
@@ -1,7 +1,13 @@
 module Approvals
   module Reporters
     module Launcher
-      REPORTERS = [:opendiff, :diffmerge, :vimdiff, :tortoisediff, :filelauncher]
+      REPORTERS = {
+        opendiff:     OpendiffReporter,
+        diffmerge:    DiffmergeReporter,
+        vimdiff:      VimdiffReporter,
+        tortoisediff: TortoisediffReporter,
+        filelauncher: FilelauncherReporter,
+      }
 
       module_function
 
@@ -13,34 +19,14 @@ module Approvals
         self.instance_variable_get(instance_variable)
       end
 
-      REPORTERS.each do |name|
+      REPORTERS.each do |name, klass|
         define_method name do
           memoized(:"@#{name}") do
-            lambda {|received, approved|
-              self.send("#{name}_command".to_sym, received, approved)
+            lambda {  |received, approved|
+              klass.command(received, approved)
             }
           end
         end
-      end
-
-      def opendiff_command(received, approved)
-        OpendiffReporter.command(received, approved)
-      end
-
-      def diffmerge_command(received, approved)
-        DiffmergeReporter.command(received, approved)
-      end
-
-      def vimdiff_command(received, approved)
-        VimdiffReporter.command(received, approved)
-      end
-
-      def tortoisediff_command(received, approved)
-        TortoisediffReporter.command(received, approved)
-      end
-
-      def filelauncher_command(received, approved)
-        FilelauncherReporter.command(received, approved)
       end
     end
   end

--- a/lib/approvals/reporters/launcher.rb
+++ b/lib/approvals/reporters/launcher.rb
@@ -24,23 +24,23 @@ module Approvals
       end
 
       def opendiff_command(received, approved)
-        "opendiff #{received} #{approved}"
+        OpendiffReporter.command(received, approved)
       end
 
       def diffmerge_command(received, approved)
-        "/Applications/DiffMerge.app/Contents/MacOS/DiffMerge --nosplash \"#{received}\" \"#{approved}\""
+        DiffmergeReporter.command(received, approved)
       end
 
       def vimdiff_command(received, approved)
-        "vimdiff #{received} #{approved}"
+        VimdiffReporter.command(received, approved)
       end
 
       def tortoisediff_command(received, approved)
-        "C:\\Program Files\\TortoiseSVN\\bin\\TortoiseMerge.exe #{received} #{approved}"
+        TortoisediffReporter.command(received, approved)
       end
 
       def filelauncher_command(received, approved)
-        "open #{received}"
+        FilelauncherReporter.command(received, approved)
       end
     end
   end

--- a/lib/approvals/reporters/launcher.rb
+++ b/lib/approvals/reporters/launcher.rb
@@ -1,5 +1,7 @@
 module Approvals
   module Reporters
+    # TODO:  this module doesn't appear to be adding much value,
+    #        and could possibly go away?
     module Launcher
       module_function
 

--- a/lib/approvals/reporters/named_reporter.rb
+++ b/lib/approvals/reporters/named_reporter.rb
@@ -1,6 +1,6 @@
 module Approvals
   module Reporters
-    class SingletonReporter
+    class NamedReporter
       def default_launcher
         Launcher.send(launcher_name)
       end

--- a/lib/approvals/reporters/named_reporter.rb
+++ b/lib/approvals/reporters/named_reporter.rb
@@ -1,6 +1,7 @@
 module Approvals
   module Reporters
     class NamedReporter
+      # TODO:  remove this if/when Launcher goes away
       def default_launcher
         Launcher.send(launcher_name)
       end

--- a/lib/approvals/reporters/opendiff_reporter.rb
+++ b/lib/approvals/reporters/opendiff_reporter.rb
@@ -2,7 +2,7 @@ module Approvals
   module Reporters
     class OpendiffReporter < NamedReporter
       def self.command(received, approved)
-        "opendiff #{received} #{approved}"
+        "opendiff \"#{received}\" \"#{approved}\""
       end
     end
   end

--- a/lib/approvals/reporters/opendiff_reporter.rb
+++ b/lib/approvals/reporters/opendiff_reporter.rb
@@ -1,6 +1,6 @@
 module Approvals
   module Reporters
-    class OpendiffReporter < SingletonReporter
+    class OpendiffReporter < NamedReporter
     end
   end
 end

--- a/lib/approvals/reporters/opendiff_reporter.rb
+++ b/lib/approvals/reporters/opendiff_reporter.rb
@@ -1,9 +1,6 @@
 module Approvals
   module Reporters
     class OpendiffReporter < SingletonReporter
-      def default_launcher
-        Launcher.opendiff
-      end
     end
   end
 end

--- a/lib/approvals/reporters/opendiff_reporter.rb
+++ b/lib/approvals/reporters/opendiff_reporter.rb
@@ -1,6 +1,9 @@
 module Approvals
   module Reporters
     class OpendiffReporter < NamedReporter
+      def self.command(received, approved)
+        "opendiff #{received} #{approved}"
+      end
     end
   end
 end

--- a/lib/approvals/reporters/opendiff_reporter.rb
+++ b/lib/approvals/reporters/opendiff_reporter.rb
@@ -1,12 +1,6 @@
 module Approvals
   module Reporters
-    class OpendiffReporter < Reporter
-      include Singleton
-
-      def self.report(received, approved)
-        instance.report(received, approved)
-      end
-
+    class OpendiffReporter < SingletonReporter
       def default_launcher
         Launcher.opendiff
       end

--- a/lib/approvals/reporters/singleton_reporter.rb
+++ b/lib/approvals/reporters/singleton_reporter.rb
@@ -6,6 +6,22 @@ module Approvals
       def self.report(received, approved)
         instance.report(received, approved)
       end
+
+      def default_launcher
+        Launcher.send(launcher_name)
+      end
+
+      private
+
+      def launcher_name
+        self
+          .class
+          .name
+          .split("::")
+          .last
+          .gsub(/Reporter$/, '')
+          .downcase
+      end
     end
   end
 end

--- a/lib/approvals/reporters/singleton_reporter.rb
+++ b/lib/approvals/reporters/singleton_reporter.rb
@@ -1,12 +1,6 @@
 module Approvals
   module Reporters
     class SingletonReporter
-      include Singleton
-
-      def self.report(received, approved)
-        instance.report(received, approved)
-      end
-
       def default_launcher
         Launcher.send(launcher_name)
       end

--- a/lib/approvals/reporters/singleton_reporter.rb
+++ b/lib/approvals/reporters/singleton_reporter.rb
@@ -1,0 +1,11 @@
+module Approvals
+  module Reporters
+    class SingletonReporter
+      include Singleton
+
+      def self.report(received, approved)
+        instance.report(received, approved)
+      end
+    end
+  end
+end

--- a/lib/approvals/reporters/tortoisediff_reporter.rb
+++ b/lib/approvals/reporters/tortoisediff_reporter.rb
@@ -1,6 +1,9 @@
 module Approvals
   module Reporters
     class TortoisediffReporter < NamedReporter
+      def self.command(received, approved)
+        "C:\\Program Files\\TortoiseSVN\\bin\\TortoiseMerge.exe #{received} #{approved}"
+      end
     end
   end
 end

--- a/lib/approvals/reporters/tortoisediff_reporter.rb
+++ b/lib/approvals/reporters/tortoisediff_reporter.rb
@@ -1,12 +1,6 @@
 module Approvals
   module Reporters
-    class TortoisediffReporter < Reporter
-      include Singleton
-
-      def self.report(received, approved)
-        instance.report(received, approved)
-      end
-
+    class TortoisediffReporter < SingletonReporter
       def default_launcher
         Launcher.tortoisediff
       end

--- a/lib/approvals/reporters/tortoisediff_reporter.rb
+++ b/lib/approvals/reporters/tortoisediff_reporter.rb
@@ -1,9 +1,6 @@
 module Approvals
   module Reporters
     class TortoisediffReporter < SingletonReporter
-      def default_launcher
-        Launcher.tortoisediff
-      end
     end
   end
 end

--- a/lib/approvals/reporters/tortoisediff_reporter.rb
+++ b/lib/approvals/reporters/tortoisediff_reporter.rb
@@ -1,6 +1,6 @@
 module Approvals
   module Reporters
-    class TortoisediffReporter < SingletonReporter
+    class TortoisediffReporter < NamedReporter
     end
   end
 end

--- a/lib/approvals/reporters/tortoisediff_reporter.rb
+++ b/lib/approvals/reporters/tortoisediff_reporter.rb
@@ -2,7 +2,7 @@ module Approvals
   module Reporters
     class TortoisediffReporter < NamedReporter
       def self.command(received, approved)
-        "C:\\Program Files\\TortoiseSVN\\bin\\TortoiseMerge.exe #{received} #{approved}"
+        "C:\\Program Files\\TortoiseSVN\\bin\\TortoiseMerge.exe \"#{received}\" \"#{approved}\""
       end
     end
   end

--- a/lib/approvals/reporters/vimdiff_reporter.rb
+++ b/lib/approvals/reporters/vimdiff_reporter.rb
@@ -1,6 +1,9 @@
 module Approvals
   module Reporters
     class VimdiffReporter < NamedReporter
+      def self.command(received, approved)
+        "vimdiff #{received} #{approved}"
+      end
     end
   end
 end

--- a/lib/approvals/reporters/vimdiff_reporter.rb
+++ b/lib/approvals/reporters/vimdiff_reporter.rb
@@ -2,7 +2,7 @@ module Approvals
   module Reporters
     class VimdiffReporter < NamedReporter
       def self.command(received, approved)
-        "vimdiff #{received} #{approved}"
+        "vimdiff \"#{received}\" \"#{approved}\""
       end
     end
   end

--- a/lib/approvals/reporters/vimdiff_reporter.rb
+++ b/lib/approvals/reporters/vimdiff_reporter.rb
@@ -1,9 +1,6 @@
 module Approvals
   module Reporters
     class VimdiffReporter < SingletonReporter
-      def default_launcher
-        Launcher.vimdiff
-      end
     end
   end
 end

--- a/lib/approvals/reporters/vimdiff_reporter.rb
+++ b/lib/approvals/reporters/vimdiff_reporter.rb
@@ -1,6 +1,6 @@
 module Approvals
   module Reporters
-    class VimdiffReporter < SingletonReporter
+    class VimdiffReporter < NamedReporter
     end
   end
 end

--- a/lib/approvals/reporters/vimdiff_reporter.rb
+++ b/lib/approvals/reporters/vimdiff_reporter.rb
@@ -1,12 +1,6 @@
 module Approvals
   module Reporters
-    class VimdiffReporter < Reporter
-      include Singleton
-
-      def self.report(received, approved)
-        instance.report(received, approved)
-      end
-
+    class VimdiffReporter < SingletonReporter
       def default_launcher
         Launcher.vimdiff
       end

--- a/spec/reporters/default_launcher_spec.rb
+++ b/spec/reporters/default_launcher_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+# TODO: delete these tests when Launcher goes away
+
 describe "#default_launcher" do
   def default_launcher_for(reporter_name)
     klass = ::Approvals::Reporters.const_get(reporter_name)

--- a/spec/reporters/default_launcher_spec.rb
+++ b/spec/reporters/default_launcher_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 describe "#default_launcher" do
   def default_launcher_for(reporter_name)
     klass = ::Approvals::Reporters.const_get(reporter_name)
-    reporter = klass.ancestors.include?(Singleton) ? klass.instance : klass.new
-    reporter.default_launcher
+    klass.new.default_launcher
   end
 
   def launcher(name)

--- a/spec/reporters/default_launcher_spec.rb
+++ b/spec/reporters/default_launcher_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe "#default_launcher" do
+  def default_launcher_for(reporter_name)
+    klass = ::Approvals::Reporters.const_get(reporter_name)
+    reporter = klass.ancestors.include?(Singleton) ? klass.instance : klass.new
+    reporter.default_launcher
+  end
+
+  def launcher(name)
+    Approvals::Reporters::Launcher.send(name)
+  end
+
+  it { expect( default_launcher_for(:DiffmergeReporter)    ).to eq launcher(:diffmerge) }
+  it { expect( default_launcher_for(:FilelauncherReporter) ).to eq launcher(:filelauncher) }
+  it { expect( default_launcher_for(:OpendiffReporter)     ).to eq launcher(:opendiff) }
+  it { expect( default_launcher_for(:TortoisediffReporter) ).to eq launcher(:tortoisediff) }
+  it { expect( default_launcher_for(:VimdiffReporter)      ).to eq launcher(:vimdiff) }
+end

--- a/spec/reporters/launcher_spec.rb
+++ b/spec/reporters/launcher_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Approvals::Reporters::Launcher do
   it "has a vimdiff launcher" do
-    expect(described_class.vimdiff.call('one', 'two')).to eq("vimdiff one two")
+    expect(described_class.vimdiff.call('one', 'two')).to eq('vimdiff "one" "two"')
   end
 
   it "has an opendiff launcher" do
-    expect(described_class.opendiff.call('one', 'two')).to eq("opendiff one two")
+    expect(described_class.opendiff.call('one', 'two')).to eq('opendiff "one" "two"')
   end
 
   it "has a diffmerge launcher" do
@@ -14,10 +14,10 @@ describe Approvals::Reporters::Launcher do
   end
 
   it "has a tortoisediff launcher" do
-    expect(described_class.tortoisediff.call('one', 'two')).to match(/TortoiseMerge.exe.*one.*two/)
+    expect(described_class.tortoisediff.call('one', 'two')).to match(/TortoiseMerge.exe.*\"one\".*\"two\"/)
   end
 
   it "has a filelauncher launcher" do
-    expect(described_class.filelauncher.call('one', 'two')).to eq("open one")
+    expect(described_class.filelauncher.call('one', 'two')).to eq('open "one"')
   end
 end


### PR DESCRIPTION
## Description

Hi, Llewellyn!  This is a followup from yesterday's pairing session.  You didn't push your branch, but it was useful for me to engage with the code anyway.  😜

This moves us closer to being able to remove `Launcher`.

## The solution

Similar to pairing session:  creates a `command` method on [some] reporter classes that builds the actual command for that reporter.  If we ignore all of the fancy metaprogramming, the only actual knowledge that `Launcher` still has at this point is the names of five reporter classes.  (These are the ones that used to be singletons; I removed the Singleton implementation and gave them a temporary superclass of `NamedReporter`.)

First commit in branch adds characterization tests around the `default_launcher` methods for those five reporter classes; those tests can be removed when that method goes away.

There are still two distinct sets of reporters:  those that inherit from `Reporter` and look like proper classes, and the five I've touched in this branch, which still look suspiciously like a glorified data structure (in that they only have one useful static method, and one inherited public instance method that only exists to satisfy the characterization tests that should go away.  That's probably for a future pairing session.

## Notation

[Arlo's git notation](https://github.com/RefactoringCombos/ArlosCommitNotation/blob/master/README.md)


