### PR TITLE
. e fix dependabot commit notations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    prefix: '- r '
+    commit-message:
+      prefix: "- r "
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-    prefix: '. e '
+    commit-message:
+      prefix: '. e '


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Replace top-level prefix entries with commit-message.prefix for npm-ecosystem and GitHub Actions